### PR TITLE
Add docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+bin/*
+node_modules/*
+
+client/node_modules/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ RUN gulp default
 # Copy the configuration file for the application
 COPY ./client/bot/user/user-config-dev.json /usr/src/aeden/bin/client/bot/user/user-config.json
 
+# Copy the DB configuration file
+COPY ./client/bot/user/pg-config-dev.json /usr/src/aeden/bin/client/bot/user/pg-config.json
+
 # Set our working directory to bin
 WORKDIR /usr/src/aeden/bin
 
@@ -48,7 +51,7 @@ RUN npm install
 RUN ./node_modules/lerna/cli.js bootstrap --hoist
 
 # Execute sed command to allow access to localhost (from Docker)
-RUN sed -i "s/\"\"/\"::ffff:172.17.0.1\"/" client/api/server/api-config.json
+RUN sed -i "s/\"\"/\"::ffff:172.0.0.0\/8\"/" client/api/server/api-config.json
 
 # Expose the listening port
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# TODO: figure out why npm within Docker doesn't run the lerna commands automatically, like non-Docker installs
+# TODO: find a cleaner way to do configuration copying, currently if you don't have a user-config-dev.json in the bin/ dir, the docker build will fail.
+
 # Select the right version of Node for the application
 FROM node:12
 
@@ -22,22 +25,28 @@ RUN npm install gulp
 COPY . .
 
 # Run the lerna bootstrap process, since for some reason npm doesn't do this automatically in docker
-RUN ./node_modules/lerna/cli.js bootstrap
+RUN ./node_modules/lerna/cli.js bootstrap --hoist
 
 # Run the gulp installer
 RUN gulp default
 
-# # Copy the configuration file for the application
+# Copy the configuration file for the application
 COPY ./client/bot/user/user-config-dev.json /usr/src/aeden/bin/client/bot/user/user-config.json
 
-# # # Set our working directory to bin
+# Set our working directory to bin
 WORKDIR /usr/src/aeden/bin
 
-# # # Use npm to install deps for the JS project
+# Use npm to install deps for the JS project
 RUN npm install
 
-# # # Expose the listening port
+# Run the lerna bootstrap process, since for some reason npm doesn't do this automatically in docker
+RUN ./node_modules/lerna/cli.js bootstrap --hoist
+
+# Execute sed command to allow access to localhost (from Docker)
+RUN sed -i "s/\"\"/\"::ffff:172.17.0.1\"/" client/api/server/api-config.json
+
+# Expose the listening port
 EXPOSE 3000
 
-# # # Start the NPM app
+# Start the NPM app
 CMD ["node", "client/aeden.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Select the right version of Node for the application
+FROM node:12
+
+# Set our working directory
+WORKDIR /usr/src/aeden
+
+# Copy the package.json and package-lock.json to install deps
+COPY package*.json ./
+
+# Copy the lerna.json file
+COPY lerna.json ./
+
+# Use npm to install deps
+RUN npm install
+
+# Install gulp
+# Need to install locally and globally, see here: https://stackoverflow.com/questions/46559549/how-to-run-gulp-task-from-dockerfile
+RUN npm install -g gulp
+RUN npm install gulp
+
+# Copy the app source
+COPY . .
+
+# Run the lerna bootstrap process, since for some reason npm doesn't do this automatically in docker
+RUN ./node_modules/lerna/cli.js bootstrap
+
+# Run the gulp installer
+RUN gulp default
+
+# # Copy the configuration file for the application
+COPY ./client/bot/user/user-config-dev.json /usr/src/aeden/bin/client/bot/user/user-config.json
+
+# # # Set our working directory to bin
+WORKDIR /usr/src/aeden/bin
+
+# # # Use npm to install deps for the JS project
+RUN npm install
+
+# # # Expose the listening port
+EXPOSE 3000
+
+# # # Start the NPM app
+CMD ["node", "client/aeden.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 # TODO: figure out why npm within Docker doesn't run the lerna commands automatically, like non-Docker installs
-# TODO: find a cleaner way to do configuration copying, currently if you don't have a user-config-dev.json in the bin/ dir, the docker build will fail.
+# TODO: find a cleaner way to do configuration copying, currently if you don't have a client/bot/user/user-config-dev.json, the docker build will fail.
+
+# Docker build instructions:
+# from root project directory: 
+#   * docker build -t aeden-docker .
+#   * docker run -p 3000:3000 -d aeden-docker
 
 # Select the right version of Node for the application
 FROM node:12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+# docker-compose instructions:
+#   * install docker-compose: https://docs.docker.com/compose/install/
+#   * docker-compose build in the root project directory to build everything
+#   * docker-compose up to start the containers
+#   * docker-compose down to stop everything and delete the containers
+
+version: '3.3'
+services:
+  aeden:
+    build: .
+    ports:
+      - '3000:3000'
+    depends_on:
+      - pg
+  pg:
+    image: postgres
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_PASSWORD: password123
+      POSTGRES_DB: aeden-db


### PR DESCRIPTION
Adding a `Dockerfile` so that we can build + test with Docker.

Tested and confirmed working with Docker version 18.09.2 in Ubuntu 18.04. Instructions for how to use the Dockerfile are included at the top, along with some TODOs to address in the future.

**Note**: One thing I couldn't sort out is why the `lerna` portion of the npm build didn't run by default in Docker like it did in my non-containerized build environment. This might be something that you're more familiar with @katagatame. It's not a breaking bug, just adds extra steps to the Docker build process that might not be needed.

Happy to revise or explain anything as needed.

-----

_12:15 - 01 Jun - katagatame__
resolves #20